### PR TITLE
# 20231124 wowalswjd (김민정) 마이페이지 푸터 스크롤 문제 수정

### DIFF
--- a/src/components/mypage/MyMenu.js
+++ b/src/components/mypage/MyMenu.js
@@ -55,7 +55,7 @@ const Wrapper = styled.div`
   box-sizing: border-box;
   padding: 10px 0;
 
-  margin-top: 12px;
+  margin: 12px 0;
 
   .container {
     width: 33%;

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -86,11 +86,11 @@ const MyPage = () => {
           <Tag name={getKorGender(profile.gender)} />
         </div>
 
-        <div style={{ marginTop: "20px" }}>
+        <div style={{ margin: "30px 0" }}>
           <Top3Badges list={badges} />
         </div>
 
-        <div className="bottom">
+        <div>
           <History
             contents={[
               {
@@ -104,7 +104,7 @@ const MyPage = () => {
           <MyMenu />
         </div>
       </Wrapper>
-      <Footer />
+      <Footer isNotFixed={true} />
     </>
   );
 };


### PR DESCRIPTION
## 📌 작업사항
- 푸터 isNotFixed로 변경하였고, 마이페이지에 있는 링크 부분 맨 밑으로 고정시키지 않고 마진을 주어서 뱃지 아래에 위치하도록 변경하였습니다.

## 📸 스크린샷(선택)
![image](https://github.com/Lets-JUPJUP/JUPJUP-Front/assets/81233784/6551dc1e-2273-4f3c-a7a4-65a457ea87ff)

## 📢 To Reviewers
현재 카카오 로그인 리다이렉트가 배포 사이트로 되어 있어서 마이페이지는 로컬로 확인하기가 어렵습니다.. 추후 다시 수정할 수도 있어요😭

## ✅ PR 체크 리스트

- [x] PR 제목을 규칙에 맞게 작성
- [x] label 설정
- [x] Code Review 요청