### PR TITLE
# 20231127 wowalswjd (김민정) 플로깅 상세 하단 푸터 고정, 페이지에 로딩 중 추가, 쓰레기통 지도 바텀시트 커스텀

### DIFF
--- a/src/components/PloggingDetail/JoinFooter.js
+++ b/src/components/PloggingDetail/JoinFooter.js
@@ -4,8 +4,6 @@ import { styled } from "styled-components";
 import ic_star_default from "../../assets/common/ic_star_default.png";
 import ic_star_clicked from "../../assets/common/ic_star_clicked.png";
 
-import useBottomDetection from "../common/useBottomDetection";
-
 import { countDDay } from "../common/time";
 import { deleteHeart, postHeart } from "../../api/heart";
 
@@ -24,8 +22,6 @@ const JoinFooter = ({
   setIsPlogJoined,
   postId,
 }) => {
-  const isScrollBottom = useBottomDetection();
-
   // 찜하기(★) 여부
   const [isStarClicked, setIsStarClicked] = useState(false);
 
@@ -57,7 +53,7 @@ const JoinFooter = ({
   };
 
   return (
-    <Wrapper className={isScrollBottom === true ? "displayNone" : ""}>
+    <Wrapper>
       <div className="main">
         <BigBoldText>{countDDay(dueDate)}</BigBoldText>
         <div className="right">
@@ -109,10 +105,6 @@ const Wrapper = styled.div`
   bottom: 0;
 
   z-index: 10;
-
-  &.displayNone {
-    display: none;
-  }
 
   .main {
     display: flex;

--- a/src/components/PloggingDetail/PloggingComment.js
+++ b/src/components/PloggingDetail/PloggingComment.js
@@ -105,7 +105,8 @@ const CommentDiv = styled.div`
   margin-top: 8px;
 
   // 하단 댓글창 높이(34px)까지 합해서 여백 만들기
-  margin-bottom: 42px;
+  margin-bottom: 100px;
+  // 댓글창 모드일 때는 42px, 하단 푸터일 때는 100px
 
   .empty {
     height: 100px;

--- a/src/components/trashmap/KakaoMap.js
+++ b/src/components/trashmap/KakaoMap.js
@@ -3,6 +3,7 @@ import { styled } from "styled-components";
 import { Map, MapMarker } from "react-kakao-maps-sdk";
 import { getTrashCanInRadius } from "../../api/trashmap";
 
+import loading from "../../assets/common/loading.gif";
 import ic_mapmarker from "../../assets/trashmap/ic_mapmarker.png";
 import pin_trash from "../../assets/trashmap/pin_trash.png";
 import pin_recycle from "../../assets/trashmap/pin_recycle.png";
@@ -130,7 +131,12 @@ const KakaoMap = ({
             : null}
         </StyledMap>
       ) : (
-        <div>로딩 중...위치 정보에 동의하지 않으셨다면 동의해주세요</div>
+        <LoadingDiv>
+          <div className="loadingContainer">
+            <img src={loading} alt="loading" className="loading" />
+            <div className="loadingText">위치 정보에 동의하지 않으셨다면 동의해주세요</div>
+          </div>
+        </LoadingDiv>
       )}
     </>
   );
@@ -148,4 +154,27 @@ const InfoWindow = styled.div`
   padding: 5px;
   background-color: var(--white, #fff);
   font-family: "Pretendard";
+`;
+
+const LoadingDiv = styled.div`
+  height: calc(100vh - 80px - 68px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .loadingContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .loading {
+    width: 100px;
+    height: 100px;
+  }
+
+  .loadingText {
+    font-size: 16px;
+    margin-top: 12px;
+  }
 `;

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -5,6 +5,7 @@ import { styled } from "styled-components";
 import Header from "../../components/common/Header";
 import GradientLine from "../../components/common/GradientLine";
 
+import loading from "../../assets/common/loading.gif";
 import default_profile from "../../assets/login/default-profile.png";
 import ic_settings from "../../assets/common/ic_settings.png";
 import edit from "../../assets/login/edit.png";
@@ -54,57 +55,65 @@ const MyPage = () => {
   return (
     <>
       <Header title="내 프로필" />
-      <Wrapper>
-        <GradientLine />
+      {Object.entries(profile).length > 0 ? (
+        <>
+          <Wrapper>
+            <GradientLine />
 
-        <div className="profileDiv">
-          <ProfileImage
-            url={profile.profileImageUrl}
-            default={default_profile}
-          />
-          <img
-            src={ic_settings}
-            alt="settings"
-            className="settings"
-            onClick={linkToUpdateMyPage}
-          />
-        </div>
+            <div className="profileDiv">
+              <ProfileImage
+                url={profile.profileImageUrl}
+                default={default_profile}
+              />
+              <img
+                src={ic_settings}
+                alt="settings"
+                className="settings"
+                onClick={linkToUpdateMyPage}
+              />
+            </div>
 
-        <div className="name">
-          <div className="name-value">{profile.nickname}</div>
-          <img
-            className="name-button"
-            src={edit}
-            alt="edit"
-            onClick={linkToUpdateMyPage}
-          />
-        </div>
-        <div className="line" />
+            <div className="name">
+              <div className="name-value">{profile.nickname}</div>
+              <img
+                className="name-button"
+                src={edit}
+                alt="edit"
+                onClick={linkToUpdateMyPage}
+              />
+            </div>
+            <div className="line" />
 
-        <div className="tags">
-          <Tag name={getAgeRange(profile.ageRange) + "대"} />
-          <Tag name={getKorGender(profile.gender)} />
-        </div>
+            <div className="tags">
+              <Tag name={getAgeRange(profile.ageRange) + "대"} />
+              <Tag name={getKorGender(profile.gender)} />
+            </div>
 
-        <div style={{ margin: "30px 0" }}>
-          <Top3Badges list={badges} />
-        </div>
+            <div style={{ margin: "30px 0" }}>
+              <Top3Badges list={badges} />
+            </div>
 
-        <div>
-          <History
-            contents={[
-              {
-                count: history.hostedPostCount,
-                text: "주최한 플로깅 모임",
-              },
-              { count: history.joinedPostCount, text: "플로깅 참여 횟수" },
-            ]}
-          />
+            <div>
+              <History
+                contents={[
+                  {
+                    count: history.hostedPostCount,
+                    text: "주최한 플로깅 모임",
+                  },
+                  { count: history.joinedPostCount, text: "플로깅 참여 횟수" },
+                ]}
+              />
 
-          <MyMenu />
-        </div>
-      </Wrapper>
-      <Footer isNotFixed={true} />
+              <MyMenu />
+            </div>
+          </Wrapper>
+          <Footer isNotFixed={true} />
+        </>
+      ) : (
+        <LoadingDiv>
+          <img src={loading} alt="loading" className="loading" />
+        </LoadingDiv>
+      )}
     </>
   );
 };
@@ -194,4 +203,16 @@ const ProfileImage = styled.div`
     `url(${
       props.url?.startsWith("https://") ? props.url : props.default
     }) gray center/cover no-repeat`};
+`;
+
+const LoadingDiv = styled.div`
+  height: calc(100vh - 80px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .loading {
+    width: 100px;
+    height: 100px;
+  }
 `;

--- a/src/pages/MyPage/MyPageUpdate.js
+++ b/src/pages/MyPage/MyPageUpdate.js
@@ -12,6 +12,8 @@ import Top3Badges from "../../components/common/Top3Badges";
 
 import Footer from "../../components/common/Footer";
 
+import loading from "../../assets/common/loading.gif";
+
 import { getAgeRange } from "../../components/common/ageRange";
 import { getKorGender } from "../../components/common/gender";
 
@@ -84,35 +86,46 @@ const MyPageUpdate = () => {
   return (
     <>
       <Header title="내 프로필 수정" />
-      <Wrapper>
-        <GradientLine />
+      {Object.entries(profile).length > 0 ? (
+        <>
+          <Wrapper>
+            <GradientLine />
 
-        {profile.profileImageUrl && (
-          <SetProfileImg
-            profileImage={profile.profileImageUrl}
-            setImgFile={setImgFile}
-          />
-        )}
+            {profile.profileImageUrl && (
+              <SetProfileImg
+                profileImage={profile.profileImageUrl}
+                setImgFile={setImgFile}
+              />
+            )}
 
-        <ValidNameCheck
-          setNickname={setNickname}
-          nickname={nickname}
-          isValid={isValid}
-          setIsValid={setIsValid}
-        />
+            <ValidNameCheck
+              setNickname={setNickname}
+              nickname={nickname}
+              isValid={isValid}
+              setIsValid={setIsValid}
+            />
 
-        <UpdateButton onClick={handleSubmit}>수정 완료</UpdateButton>
+            <UpdateButton onClick={handleSubmit}>수정 완료</UpdateButton>
 
-        <div className="tags">
-          <Tag name={getAgeRange(profile.ageRange) + "대"} status="finish" />
-          <Tag name={getKorGender(profile.gender)} status="finish" />
-        </div>
+            <div className="tags">
+              <Tag
+                name={getAgeRange(profile.ageRange) + "대"}
+                status="finish"
+              />
+              <Tag name={getKorGender(profile.gender)} status="finish" />
+            </div>
 
-        <div style={{ marginTop: "20px" }}>
-          <Top3Badges list={badges} />
-        </div>
-      </Wrapper>
-      <Footer isNotFixed={true} />
+            <div style={{ marginTop: "20px" }}>
+              <Top3Badges list={badges} />
+            </div>
+          </Wrapper>
+          <Footer isNotFixed={true} />
+        </>
+      ) : (
+        <LoadingDiv>
+          <img src={loading} alt="loading" className="loading" />
+        </LoadingDiv>
+      )}
     </>
   );
 };
@@ -174,4 +187,16 @@ const UpdateButton = styled.button`
   border: 0px;
 
   margin-top: 22px;
+`;
+
+const LoadingDiv = styled.div`
+  height: calc(100vh - 80px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .loading {
+    width: 100px;
+    height: 100px;
+  }
 `;

--- a/src/pages/Plogging/PloggingDetailPage.js
+++ b/src/pages/Plogging/PloggingDetailPage.js
@@ -5,6 +5,7 @@ import { styled } from "styled-components";
 import Header from "../../components/common/Header";
 
 import ic_close from "../../assets/common/ic_close.png";
+import loading from "../../assets/common/loading.gif";
 
 import PostImageBox from "../../components/PloggingDetail/PostImageBox";
 import KakaoShareBtn from "../../components/PloggingDetail/KakaoShareBtn";
@@ -218,7 +219,9 @@ const PloggingDetailPage = () => {
           </Wrapper>
         </>
       ) : (
-        <div style={{ marginTop: "100px" }}>로딩 중..</div>
+        <LoadingDiv>
+          <img src={loading} alt="loading" className="loading" />
+        </LoadingDiv>
       )}
     </>
   );
@@ -267,4 +270,17 @@ const CommentLine = styled.div`
   height: 1.2px;
   background: var(--light, "#f3efff");
   margin: 12px 0;
+`;
+
+const LoadingDiv = styled.div`
+  margin-top: 80px;
+  height: calc(100vh - 80px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .loading {
+    width: 100px;
+    height: 100px;
+  }
 `;

--- a/src/pages/TrashMap/TrashMapPage.js
+++ b/src/pages/TrashMap/TrashMapPage.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import Header from "../../components/common/Header";
 import KakaoMap from "../../components/trashmap/KakaoMap";
@@ -19,6 +19,24 @@ const TrashMapPage = () => {
   // 사용자가 선택한 쓰레기통 정보
   const [selectedData, setSelectedData] = useState(null);
 
+  // 바텀시트
+  const bottomSheetRef = useRef();
+
+  // 각 쓰레기통에 대한 피드백 posted 여부
+  const initalArr = [
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+  ];
+  const [feedbackPosted, setFeedbackPosted] = useState(initalArr);
+
   // BottomSheet open 여부
   const [bsOpen, setBsOpen] = useState(false);
 
@@ -38,8 +56,34 @@ const TrashMapPage = () => {
         setBsOpen={setBsOpen}
         setSelectedData={setSelectedData}
       />
-      <StyledBottomSheet open={bsOpen} onDismiss={onDisMiss}>
-        <TrashBottomSheet selectedData={selectedData}/>
+      <StyledBottomSheet
+        ref={bottomSheetRef}
+        open={bsOpen}
+        onDismiss={onDisMiss}
+        snapPoints={({ headerHeight }) => [
+          headerHeight + 68,
+          headerHeight + 500,
+        ]}
+        defaultSnap={({ headerHeight }) => headerHeight + 68}
+        header={
+          <div
+            onClick={() => {
+              bottomSheetRef.current.snapTo(
+                ({ headerHeight }) => headerHeight + 500
+              );
+            }}
+          >
+            해당 쓰레기통에 대한 의견을 남겨주세요
+          </div>
+        }
+        expandOnContentDrag={true}
+      >
+        <TrashBottomSheet
+          selectedData={selectedData}
+          feedbackPosted={feedbackPosted}
+          setFeedbackPosted={setFeedbackPosted}
+          initalArr={initalArr}
+        />
       </StyledBottomSheet>
       <AdBanner />
     </>
@@ -49,7 +93,16 @@ const TrashMapPage = () => {
 export default TrashMapPage;
 
 const StyledBottomSheet = styled(BottomSheet)`
-  /* [data-rsbs-header] {
-    background-color: var(--main);
-  } */
+  [data-rsbs-header]:before {
+    background-color: var(--white, "#fff");
+  }
+
+  [data-rsbs-header] {
+    border-top-left-radius: 16px;
+    border-top-left-radius: var(--rsbs-overlay-rounded, 16px);
+    border-top-right-radius: 16px;
+    border-top-right-radius: var(--rsbs-overlay-rounded, 16px);
+    background-color: var(--main, "#410FD4");
+    color: var(--white, "#fff");
+  }
 `;


### PR DESCRIPTION
## 📌 작업사항
- 플로깅 상세 페이지 하단 푸터 스크롤하면 없어지지 않고 하단에 고정하도록 수정
- 마이페이지, 마이페이지 수정, 플로깅 상세 페이지, 지도 컴포넌트에 로딩 중 gif 추가
- 쓰레기통 지도 페이지 바텀시트 피그마처럼 커스텀

## 📸 스크린샷(선택)
![image](https://github.com/Lets-JUPJUP/JUPJUP-Front/assets/81233784/b1f429a8-c3fe-48eb-9db5-c81512f4745c)
![image](https://github.com/Lets-JUPJUP/JUPJUP-Front/assets/81233784/895ced91-efcf-45b4-afa2-058c9b28f0f6)


## 📢 To Reviewers
오늘 새벽쯤에 피드백 보내기 & 피드백 조회 추가해서 마무리하겠습니다

## ✅ PR 체크 리스트

- [x] PR 제목을 규칙에 맞게 작성
- [x] label 설정
- [x] Code Review 요청