### PR TITLE
# 20231130 wowalswjd (김민정) 마이페이지 수정 페이지 배지 관련 오류 수정, 카카오맵 인포윈도우 가운데 정렬

### DIFF
--- a/src/components/trashmap/KakaoMap.js
+++ b/src/components/trashmap/KakaoMap.js
@@ -162,6 +162,11 @@ const InfoWindow = styled.div`
   padding: 5px;
   background-color: var(--white, #fff);
   font-family: "Pretendard";
+  font-weight: 600;
+
+  width: 150px;
+  max-width: 180px;
+  text-align: center;
 `;
 
 const LoadingDiv = styled.div`

--- a/src/pages/MyPage/MyPageUpdate.js
+++ b/src/pages/MyPage/MyPageUpdate.js
@@ -42,7 +42,7 @@ const MyPageUpdate = () => {
       const data_badges = (await reviewsGetTop3Reviews(userId)).data.data;
 
       data_profile && setProfile(data_profile);
-      data_badges && setBadges(data_badges.bages);
+      data_badges && setBadges(data_badges.badges);
 
       setNickname(data_profile.nickname);
       // 초기 닉네임 설정
@@ -117,7 +117,7 @@ const MyPageUpdate = () => {
               <Tag name={getKorGender(profile.gender)} status="finish" />
             </div>
 
-            <div style={{ marginTop: "20px" }}>
+            <div style={{ marginTop: "30px" }}>
               <Top3Badges list={badges} />
             </div>
           </Wrapper>


### PR DESCRIPTION
## 📌 작업사항
- 마이페이지 수정 페이지 배지 관련 오류 수정
- 카카오맵 인포윈도우 가운데 정렬

## 📸 스크린샷(선택)
![image](https://github.com/Lets-JUPJUP/JUPJUP-Front/assets/81233784/27062dd7-3110-41c7-bf9c-38292494abd4)

## 📢 To Reviewers
이제 더 이상 수정은 없을 것 같고, 시간이 난 다면 PC 뷰 추가 정도 진행할 것 같습니다

## ✅ PR 체크 리스트

- [x] PR 제목을 규칙에 맞게 작성
- [x] label 설정
- [x] Code Review 요청